### PR TITLE
GUI: Align stack switcher for info_stack to center

### DIFF
--- a/src/gui/gtk3/interface.glade
+++ b/src/gui/gtk3/interface.glade
@@ -251,15 +251,27 @@ Author: Michael Aaron Murphy <mmstickman@gmail.com>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkStackSwitcher">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="stack">info_stack</property>
+                    <property name="homogeneous">True</property>
+                    <child>
+                      <object class="GtkStackSwitcher">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="stack">info_stack</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
@@ -387,7 +399,7 @@ Author: Michael Aaron Murphy <mmstickman@gmail.com>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
Put the stack switcher inside a Box and adjust Fill property to make stack switcher button align to center.

Signed-off-by: Aurabindo J <mail@aurabindo.in>