### PR TITLE
add installation instructions for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ In the event that you would like to uninstall the application, simply run the fo
 sudo make uninstall
 ```
 
+#### Ubuntu
+
+To build from source on a clean ubuntu 16.04:
+
+```
+curl https://sh.rustup.rs -sSf | sh
+source ~/.profile
+sudo apt-get install libgtk-3-dev
+make
+sudo make install
+```
+
 ## Screenshots
 
 ![Services](screenshot-services.png)


### PR DESCRIPTION
Installing libgtk-3-dev avoids the following error:
```
error: failed to run custom build command for `pango-sys v0.3.3`
process didn't exit successfully: `/home/nmaris/my/unversioned/systemd-manager/target/release/build/pango-sys-39580209d38ba701/build-script-build` (exit code: 1)
--- stderr
`"pkg-config" "--libs" "--cflags" "pango >= 1.34"` did not exit successfully: exit code: 1
--- stderr
Package pango was not found in the pkg-config search path.
Perhaps you should add the directory containing `pango.pc'
to the PKG_CONFIG_PATH environment variable
No package 'pango' found

warning: build failed, waiting for other jobs to finish...
error: build failed
Makefile:6: recipe for target 'all' failed
make: *** [all] Error 101
```